### PR TITLE
deps: Tier E migration (shapely 2 + osmnx) and dead-pin cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,13 +75,15 @@ WORKDIR /app
 # Copy requirements first for better caching
 COPY requirements.txt .
 
-# Install PyTorch with CUDA support from PyTorch index, then other requirements
-# Note: detectron2 is installed separately after torch because its setup.py imports torch
+# Install PyTorch with CUDA support from PyTorch index, then the rest of requirements.
+# detectron2 was previously installed here as well, but no Python in this codebase
+# imports it (the Mask R-CNN rocks model runs as a remote service via
+# MASKRCNN_ROCKS_API_URL). Re-add only if a future analyzer needs in-process
+# detectron2 — note that it locks the numpy/torch ABI and has long build times.
 RUN pip install --no-cache-dir torch torchvision \
         --index-url https://download.pytorch.org/whl/cu121 && \
     pip install --no-cache-dir -r requirements.txt && \
-    pip install --no-cache-dir fiona==$(pip show fiona | grep Version | cut -d' ' -f2) --no-binary fiona && \
-    pip install --no-cache-dir --no-build-isolation 'git+https://github.com/facebookresearch/detectron2.git' || \
+    pip install --no-cache-dir fiona==$(pip show fiona | grep Version | cut -d' ' -f2) --no-binary fiona || \
     (echo "Failed to install requirements" && exit 1)
 
 # Create models directory for YOLO weights (auto-downloaded on first use)

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,9 +27,11 @@ vine==5.1.0
 tzdata==2025.3
 
 # --- Database / server ---------------------------------------------------------
-psycopg2-binary==2.9.11
-gunicorn==23.0.0
-whitenoise==6.11.0
+# psycopg2-binary, whitenoise, gunicorn intentionally absent:
+#   - DATABASES uses sqlite3 (see deepgis_xr/settings.py); no Postgres in compose.
+#   - settings.py serves staticfiles/ via STATICFILES_DIRS — collectstatic disabled.
+#   - Dev/container both run `manage.py runserver` (see docker-compose.yml).
+# Re-add when production switches to Postgres + WhiteNoise/Gunicorn.
 
 # --- Imaging / media -----------------------------------------------------------
 Pillow==11.3.0
@@ -37,42 +39,49 @@ opencv-python==4.11.0.86
 ImageIO==2.37.2
 scikit-image==0.24.0
 tifffile==2024.8.30
-numpy-stl==3.2.0
+# numpy-stl removed: not imported anywhere; STL handling lives in services/topology
+# via trimesh.
 
 # --- Scientific stack ----------------------------------------------------------
-# numpy 1.23.x is a hard floor for the compiled wheels detectron2 ships against;
-# bumping requires recompiling detectron2. See Dockerfile.
-numpy==1.23.5
+# Tier E migration (2026-04-23): numpy/pandas/shapely/geopandas bumped to versions
+# compatible with osmnx 1.9.x (required by kernelcal.urban). Verified that the
+# rest of the stack (torch 2.5.1+cu121, opencv 4.11, rasterio 1.3, fiona 1.9,
+# scikit-image 0.24, pyproj 3.5) loads cleanly under these versions.
+numpy==1.26.4
 scipy==1.13.1           # Required for world sampler spatial indexing (KDTree)
-pandas==2.3.3
+pandas==2.2.3
 matplotlib==3.9.4
 
 # --- GIS -----------------------------------------------------------------------
 # GDAL is pinned via `gdal-config --version` in the Dockerfile (system lib).
 rasterio==1.3.0
-Shapely==1.8.0          # Still 1.x; 2.x is an API break (Tier E)
+shapely==2.0.7          # Tier E: bumped from 1.8 (osmnx>=1.7 requires shapely>=2)
 Fiona==1.9.1
-geopandas==0.12.0
+geopandas==0.14.4       # Tier E: bumped from 0.12 (transitive of shapely 2)
 pyproj==3.5.0
 Rtree==1.0.1
 affine==2.4.0
 cligj==0.7.2
 munch==4.0.0
 snuggs==1.4.7
+# OSMnx for the world-sampler urban_spectral analyzer
+# (kernelcal.urban.fetch_buildings_bbox). Pinned to 1.x for now; 2.x is a
+# breaking API change (positional args removed, bbox tuple order swapped).
+osmnx>=1.9,<2
 
 # --- Phone auth (Twilio) -------------------------------------------------------
 twilio==9.9.0
 django-phonenumber-field==8.0.0
 phonenumbers==9.0.21
-PyJWT==2.10.1
+# PyJWT removed: not imported anywhere (no DRF SimpleJWT, no custom JWT auth).
 
 # --- AI / ML — object detection & segmentation --------------------------------
-# Torch + torchvision + detectron2 are installed in the Dockerfile, NOT here:
+# Torch + torchvision are installed in the Dockerfile, NOT here:
 #   - torch==2.5.1+cu121 / torchvision==0.20.1+cu121 come from the PyTorch
 #     CUDA 12.1 index (see Dockerfile RUN pip install torch torchvision ...).
-#   - detectron2 is installed from GitHub after torch is present (its setup.py
-#     imports torch at build time).
-# See Dockerfile for the authoritative install order.
+# detectron2 was previously installed in the Dockerfile but is not imported
+# anywhere in this codebase; the Mask R-CNN rocks model runs as a remote
+# service (MASKRCNN_ROCKS_API_URL). Removed in the Tier E cleanup.
 ultralytics==8.3.241
 # Segment Anything Model — pinned by SHA via Docker install for reproducibility.
 # Adding here is a no-op inside Docker (already installed) but useful for non-Docker


### PR DESCRIPTION
Bumps the GIS/scientific stack to versions compatible with osmnx 1.9.x, which kernelcal.urban requires for the world-sampler urban_spectral analyzer. Also drops pins that aren't imported anywhere in the codebase.

Tier E pin bumps:
  numpy     1.23.5 → 1.26.4
  pandas    2.3.3  → 2.2.3
  Shapely   1.8.0  → shapely 2.0.7   (API break the comment warned about)
  geopandas 0.12.0 → 0.14.4
  + osmnx>=1.9,<2  (new)

Removed (verified zero imports across deepgis_xr/ and services/):
  psycopg2-binary  – DATABASES uses sqlite3, no postgres in compose
  whitenoise       – not in MIDDLEWARE; collectstatic is disabled by design
  gunicorn         – Dockerfile/compose run manage.py runserver
  numpy-stl (stl)  – STL handling lives in services/topology via trimesh
  PyJWT (jwt)      – no DRF SimpleJWT, no custom JWT auth

Dockerfile:
  Drop the detectron2 install line. No Python in this codebase imports
  detectron2; the Mask R-CNN rocks model is a remote service
  (MASKRCNN_ROCKS_API_URL). Saves significant build time and removes a
  numpy/torch ABI lock.

Validated against the live container (deepgis-xr_web_1):
  - 42-module import smoke test passes (django, DRF, celery, all 8 world_sampler analyzers, full GIS stack, kernelcal, osmnx, torch).
  - urban_spectral end-to-end on Tempe ASU bbox: 47 buildings, 165 edges, β0=1, β1=119, λ_F=0.097, ΔH=-0.62, MaxCal converged in 11 iters, total 2.1s.

Out of scope (flagged for follow-up):
  - convert_images.py imports bs4/wand/cairosvg, none of which are in requirements.txt or the running container. Either wire them in or delete the dead code paths in apps/core/image_processing/ and apps/core/utils/search.py (uses webclient.image_ops shim).

Made-with: Cursor